### PR TITLE
Map admin roles to API access

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,4 +1,7 @@
 security:
+    role_hierarchy:
+        ROLE_ROOT: ['ROLE_ADMINISTRATION_ACCESS', 'ROLE_API_ACCESS']
+        ROLE_ADMIN: ['ROLE_ADMINISTRATION_ACCESS', 'ROLE_API_ACCESS']
     providers:
         sylius_admin_user_provider:
             id: sylius.admin_user_provider.email_or_name_based


### PR DESCRIPTION
## Summary
- add a role hierarchy so ROLE_ROOT and ROLE_ADMIN automatically grant the roles required by the admin API firewall

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691916ce1ba48326b556526b3496168d)